### PR TITLE
ShimmerContainer and maskElements leaking views on multiple calls to VeilLayout#setLayout(View)

### DIFF
--- a/androidveil/src/main/java/com/skydoves/androidveil/VeilLayout.kt
+++ b/androidveil/src/main/java/com/skydoves/androidveil/VeilLayout.kt
@@ -79,7 +79,6 @@ class VeilLayout : FrameLayout {
   var isVeiled = false
     private set
 
-  private val maskElements = ArrayList<View>()
   val shimmerContainer = ShimmerFrameLayout(context)
   val nonShimmer = Shimmer.AlphaHighlightBuilder().setBaseAlpha(1.0f).setDropoff(1.0f).build()
   var shimmer = Shimmer.AlphaHighlightBuilder().build()
@@ -174,6 +173,7 @@ class VeilLayout : FrameLayout {
   fun setLayout(layout: View) {
     removeAllViews()
     addView(layout)
+    shimmerContainer.removeAllViews()
     onFinishInflate()
   }
 
@@ -224,7 +224,6 @@ class VeilLayout : FrameLayout {
               setColor(Color.DKGRAY)
               cornerRadius = radius
             }
-            maskElements.add(this)
             shimmerContainer.addView(this)
           }
         }


### PR DESCRIPTION
VeilLayout#maskElements was an array that was seemingly unused, but multiple calls to setLayout would retain all previously held views and append the new views.

VeilLayout#shimmerContainer would eventually grow in size as multiple setLayout calls were made. This was remedied by removing all the views contained on setLayout. 

I'm not sure many people have the same use case as I do, but for some of the views that I have their internals have mutable visibility and require multiple refreshes of the shimmer container contents. I was thinking that maybe I should also add an `invalidateVeil` that skips the removal of the contained layout, but recalculates the shimmer container. Not sure this is something that you'd be interested in, but probably calls for a seperate "New feature" PR. 

Gradle spotless apply passes on this PR. 

## Guidelines
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

### Types of changes
What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.