### PR TITLE
hide Veil recyclerView with gone 

### DIFF
--- a/androidveil/src/main/java/com/skydoves/androidveil/VeilRecyclerFrameView.kt
+++ b/androidveil/src/main/java/com/skydoves/androidveil/VeilRecyclerFrameView.kt
@@ -248,14 +248,14 @@ class VeilRecyclerFrameView : RelativeLayout {
   private fun visibleVeilRecyclerView() {
     this.veiledRecyclerView.visible()
     this.veiledRecyclerView.bringToFront()
-    this.userRecyclerView.invisible()
+    this.userRecyclerView.gone()
   }
 
   /** Invisible veiledRecyclerView and Visible userRecyclerView. */
   private fun visibleUserRecyclerView() {
     this.userRecyclerView.visible()
     this.userRecyclerView.bringToFront()
-    this.veiledRecyclerView.invisible()
+    this.veiledRecyclerView.gone()
   }
 
   /** Apply overscrollModel of parent to veiled and user recyclerview. */

--- a/androidveil/src/main/java/com/skydoves/androidveil/ViewExtension.kt
+++ b/androidveil/src/main/java/com/skydoves/androidveil/ViewExtension.kt
@@ -24,6 +24,11 @@ internal fun View.visible() {
   this.visibility = View.VISIBLE
 }
 
+@JvmSynthetic
+internal fun View.gone() {
+  this.visibility = View.GONE
+}
+
 /** Makes invisible a view. */
 @JvmSynthetic
 internal fun View.invisible() {


### PR DESCRIPTION
## Guidelines
my problem was when setup veil recycler View with large number of items like 15 and the actual data 
returned be less than this number say 1 item 
the veil recycler view still take the same space of 15 items and that cause a large white space  

### Types of changes
What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
